### PR TITLE
Implement basic React student portal skeleton

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,26 @@
+import { Routes, Route, Navigate } from "react-router-dom";
+import Login from "@pages/Login";
+import SelectStudent from "@pages/SelectStudent";
+import Dashboard from "@pages/Dashboard";
+import Subjects from "@pages/Subjects";
+import Absences from "@pages/Absences";
+import ProtectedRoute from "@router/ProtectedRoute";
+import Navbar from "@components/Navbar";
+
+export default function App() {
+  return (
+    <>
+      <Navbar />
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/select-student" element={<SelectStudent />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/subjects" element={<Subjects />} />
+          <Route path="/absences" element={<Absences />} />
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        </Route>
+      </Routes>
+    </>
+  );
+}

--- a/src/components/AbsencesSummary.tsx
+++ b/src/components/AbsencesSummary.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { api } from "@services/api";
+import { useAuth } from "@contexts/AuthContext";
+
+interface SummaryItem {
+  subject: string;
+  absences: number;
+}
+
+export default function AbsencesSummary() {
+  const { apiKey, student } = useAuth();
+  const [summary, setSummary] = useState<SummaryItem[]>([]);
+
+  useEffect(() => {
+    if (!apiKey || !student) return;
+    api.getAbsenceSummary(apiKey, student.id)
+      .then(setSummary)
+      .catch(console.error);
+  }, [apiKey, student]);
+
+  return (
+    <div className="home-section">
+      <h2 className="title mb-2">Resumen Asistencias</h2>
+      <ul className="list-disc list-inside">
+        {summary.map((s) => (
+          <li key={s.subject}>{s.subject}: {s.absences}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/AbsencesTable.tsx
+++ b/src/components/AbsencesTable.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { api } from "@services/api";
+import { useAuth } from "@contexts/AuthContext";
+
+interface Absence {
+  id: number;
+  date: string;
+  subject: string;
+  reason?: string;
+}
+
+export default function AbsencesTable() {
+  const { apiKey, student } = useAuth();
+  const [absences, setAbsences] = useState<Absence[]>([]);
+
+  useEffect(() => {
+    if (!apiKey || !student) return;
+    api.getAbsences(apiKey, student.id)
+      .then(setAbsences)
+      .catch(console.error);
+  }, [apiKey, student]);
+
+  return (
+    <table className="min-w-full border">
+      <thead>
+        <tr>
+          <th className="border px-2">Fecha</th>
+          <th className="border px-2">Materia</th>
+          <th className="border px-2">Motivo</th>
+        </tr>
+      </thead>
+      <tbody>
+        {absences.map((a) => (
+          <tr key={a.id}>
+            <td className="border px-2">{a.date}</td>
+            <td className="border px-2">{a.subject}</td>
+            <td className="border px-2">{a.reason || "-"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,24 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "@contexts/AuthContext";
+
+export default function Navbar() {
+  const { apiKey, student, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login");
+  };
+
+  if (!apiKey) return null;
+
+  return (
+    <nav className="bg-secondary p-2 flex gap-4">
+      <Link to="/dashboard">Inicio</Link>
+      <Link to="/subjects">Materias</Link>
+      <Link to="/absences">Asistencias</Link>
+      <span className="ml-auto">{student?.name}</span>
+      <button onClick={handleLogout} className="underline">Cerrar sesión</button>
+    </nav>
+  );
+}

--- a/src/components/SubjectsList.tsx
+++ b/src/components/SubjectsList.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { api } from "@services/api";
+import { useAuth } from "@contexts/AuthContext";
+
+interface Subject {
+  id: number;
+  name: string;
+  code: string;
+  location?: string;
+}
+
+export default function SubjectsList({ preview }: { preview?: boolean }) {
+  const { apiKey, student } = useAuth();
+  const [subjects, setSubjects] = useState<Subject[]>([]);
+
+  useEffect(() => {
+    if (!apiKey || !student) return;
+    api.getEnrollments(apiKey, student.id)
+      .then(setSubjects)
+      .catch(console.error);
+  }, [apiKey, student]);
+
+  const shown = preview ? subjects.slice(0, 2) : subjects;
+
+  return (
+    <div className="home-section">
+      <h2 className="title mb-2">Materias</h2>
+      <ul className="list-disc list-inside">
+        {shown.map((s) => (
+          <li key={s.id}>{s.name} ({s.code})</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, ReactNode } from "react";
+import { useStorageState } from "@hooks/useStorageState";
+
+export interface Student {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+interface AuthContextType {
+  apiKey: string | null;
+  student: Student | null;
+  login: (key: string) => void;
+  logout: () => void;
+  selectStudent: (s: Student) => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [apiKey, setApiKey] = useStorageState<string | null>("apiKey", null);
+  const [student, setStudent] = useStorageState<Student | null>("student", null);
+
+  const login = (key: string) => setApiKey(key);
+  const logout = () => {
+    setApiKey(null);
+    setStudent(null);
+  };
+  const selectStudent = (s: Student) => setStudent(s);
+
+  return (
+    <AuthContext.Provider value={{ apiKey, student, login, logout, selectStudent }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/src/hooks/useStorageState.ts
+++ b/src/hooks/useStorageState.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+export function useStorageState<T>(key: string, initial: T) {
+  const [state, setState] = useState<T>(() => {
+    const item = localStorage.getItem(key);
+    return item ? (JSON.parse(item) as T) : initial;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [key, state]);
+
+  return [state, setState] as const;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
+import "@styles/index.css";
+import { AuthProvider } from "@contexts/AuthContext";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Absences.tsx
+++ b/src/pages/Absences.tsx
@@ -1,0 +1,10 @@
+import AbsencesTable from "@components/AbsencesTable";
+
+export default function Absences() {
+  return (
+    <div className="p-4">
+      <h1 className="title mb-4">Inasistencias</h1>
+      <AbsencesTable />
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,19 @@
+import { useAuth } from "@contexts/AuthContext";
+import AbsencesSummary from "@components/AbsencesSummary";
+import SubjectsList from "@components/SubjectsList";
+
+export default function Dashboard() {
+  const { student } = useAuth();
+  if (!student) return null;
+
+  return (
+    <div className="p-4">
+      <h1 className="title mb-4">Dashboard</h1>
+      <p className="mb-4">Bienvenido {student.name}</p>
+      <div className="grid gap-4 md:grid-cols-2">
+        <SubjectsList preview />
+        <AbsencesSummary />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@contexts/AuthContext";
+
+export default function Login() {
+  const [key, setKey] = useState("");
+  const { login, apiKey } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (key) {
+      login(key);
+      navigate("/select-student");
+    }
+  };
+
+  if (apiKey) {
+    navigate("/select-student");
+  }
+
+  return (
+    <div className="p-4 login-section">
+      <h1 className="title mb-4">API Login</h1>
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <input
+          type="text"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="API key"
+          className="border p-2 flex-1"
+        />
+        <button type="submit" className="bg-primary text-white px-4">
+          Entrar
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/SelectStudent.tsx
+++ b/src/pages/SelectStudent.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth, Student } from "@contexts/AuthContext";
+import { api } from "@services/api";
+
+export default function SelectStudent() {
+  const { apiKey, selectStudent } = useAuth();
+  const [students, setStudents] = useState<Student[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!apiKey) return;
+    api.getStudents(apiKey)
+      .then(setStudents)
+      .catch(console.error);
+  }, [apiKey]);
+
+  const handleSelect = (id: number) => {
+    const s = students.find((st) => st.id === id);
+    if (s) {
+      selectStudent(s);
+      navigate("/dashboard");
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="title mb-4">Seleccionar Estudiante</h1>
+      <ul className="space-y-2">
+        {students.map((s) => (
+          <li key={s.id}>
+            <button className="underline" onClick={() => handleSelect(s.id)}>
+              {s.name}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -1,0 +1,10 @@
+import SubjectsList from "@components/SubjectsList";
+
+export default function Subjects() {
+  return (
+    <div className="p-4">
+      <h1 className="title mb-4">Materias</h1>
+      <SubjectsList />
+    </div>
+  );
+}

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "@contexts/AuthContext";
+
+export default function ProtectedRoute() {
+  const { apiKey } = useAuth();
+  if (!apiKey) {
+    return <Navigate to="/login" replace />;
+  }
+  return <Outlet />;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,19 @@
+const API_BASE = "https://api.example.com";
+
+async function request(path: string, apiKey: string) {
+  const res = await fetch(API_BASE + path, {
+    headers: { "x-api-key": apiKey },
+  });
+  if (!res.ok) {
+    throw new Error("API error");
+  }
+  return res.json();
+}
+
+export const api = {
+  getStudents: (key: string) => request("/students/", key),
+  getStudentProfile: (key: string, id: number) => request(`/students/${id}/`, key),
+  getEnrollments: (key: string, id: number) => request(`/enrollments/?student_id=${id}`, key),
+  getAbsences: (key: string, id: number) => request(`/absences/?student_id=${id}`, key),
+  getAbsenceSummary: (key: string, id: number) => request(`/students/${id}/absence_summary/`, key),
+};


### PR DESCRIPTION
## Summary
- add an Auth context with localStorage persistence
- create ProtectedRoute component
- implement basic API wrapper
- define main router and pages (login, select student, dashboard, subjects, absences)
- add reusable components for navbar, subjects and absences
- setup app entry with router and provider

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685b9040843c8330a3f0cf3a6e195e50